### PR TITLE
Update latex.py

### DIFF
--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -207,7 +207,7 @@ class LatexPrinter(Printer):
 
     def parenthesize(self, item, level, strict=False):
         prec_val = precedence_traditional(item)
-        if (prec_val < level) or ((not strict) and prec_val <= level):
+        if (prec_val <= level) or ((not strict) and prec_val <= level):
             return r"\left({}\right)".format(self._print(item))
         else:
             return self._print(item)


### PR DESCRIPTION
Fixes issue #18731

#### Brief description of what is fixed or changed
In the parenthesis function, the value of **prec_val** would always be less than equal to level 
but it was set to less than level previously

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->